### PR TITLE
Call `markForCheck` instead of `detectChanges`

### DIFF
--- a/src/app/public/modules/list-view-grid/list-view-grid.component.ts
+++ b/src/app/public/modules/list-view-grid/list-view-grid.component.ts
@@ -312,7 +312,7 @@ export class SkyListViewGridComponent
         }
       })
       .map((result: AsyncList<ListItemModel>) => {
-        this.changeDetector.detectChanges();
+        this.changeDetector.markForCheck();
         return result.items;
       })
       .distinctUntilChanged();


### PR DESCRIPTION
I'm getting an `ExpressionChangedAfterItHasBeenCheckedError` error.